### PR TITLE
Reorder projects on projects page

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -102,22 +102,22 @@ const categoryThemes: Record<string, CategoryTheme> = {
 // Project data with enhanced details
 const projects: Project[] = [
   {
-    title: "OurStories",
+    title: "LinkedIn Applicant Counter",
     description:
-      "I created this bedtime story generator that makes children the stars of their own stories—complete with AI-generated images that incorporate their photos. A passion project that combines storytelling with cutting-edge AI.",
-    image: "/forest-friends-picnic.png",
-    category: "AI",
-    tags: ["AI", "NLP", "Image Generation", "E-commerce"],
-    techStack: ["Next", "Typescript", "API", "AI", "React"],
-    link: "/projects/ourstories",
-    githubLink: "https://github.com/BlakeDanielson/OurStoriesV3",
-    liveLink: "https://ourstories.app",
+      "A Chrome extension that automatically reveals the true number of applicants on LinkedIn job postings by extracting counts from API data and displaying them directly on the page.",
+    image: "/linkedin-applicant-counter.png",
+    category: "Web App",
+    tags: ["Chrome Extension", "LinkedIn", "Job Search", "UX"],
+    techStack: ["JavaScript", "Manifest v3", "Chrome APIs", "CSS"],
+    link: "/projects/linkedin-applicant-counter",
+    githubLink: "https://github.com/BlakeDanielson/HowManyApplied",
+    liveLink: null,
     featured: false,
-    icon: <BookOpen className="h-5 w-5" />,
-    status: "In Development",
-    pricing: "Premium",
-    completionDate: "2025-03",
-    duration: "3 months"
+    icon: <Code className="h-5 w-5" />,
+    status: "Live",
+    pricing: "Free",
+    completionDate: "2025-08",
+    duration: "1 week"
   },
   {
     title: "Mood2Song",
@@ -210,22 +210,22 @@ const projects: Project[] = [
     duration: "2 weeks"
   },
   {
-    title: "LinkedIn Applicant Counter",
+    title: "OurStories",
     description:
-      "A Chrome extension that automatically reveals the true number of applicants on LinkedIn job postings by extracting counts from API data and displaying them directly on the page.",
-    image: "/linkedin-applicant-counter.png",
-    category: "Web App",
-    tags: ["Chrome Extension", "LinkedIn", "Job Search", "UX"],
-    techStack: ["JavaScript", "Manifest v3", "Chrome APIs", "CSS"],
-    link: "/projects/linkedin-applicant-counter",
-    githubLink: "https://github.com/BlakeDanielson/HowManyApplied",
-    liveLink: null,
+      "I created this bedtime story generator that makes children the stars of their own stories—complete with AI-generated images that incorporate their photos. A passion project that combines storytelling with cutting-edge AI.",
+    image: "/forest-friends-picnic.png",
+    category: "AI",
+    tags: ["AI", "NLP", "Image Generation", "E-commerce"],
+    techStack: ["Next", "Typescript", "API", "AI", "React"],
+    link: "/projects/ourstories",
+    githubLink: "https://github.com/BlakeDanielson/OurStoriesV3",
+    liveLink: "https://ourstories.app",
     featured: false,
-    icon: <Code className="h-5 w-5" />,
-    status: "Live",
-    pricing: "Free",
-    completionDate: "2025-08",
-    duration: "1 week"
+    icon: <BookOpen className="h-5 w-5" />,
+    status: "In Development",
+    pricing: "Premium",
+    completionDate: "2025-03",
+    duration: "3 months"
   },
   {
     title: "Caren's Cookbook",


### PR DESCRIPTION
Reorder projects on the `/projects` page to display 'LinkedIn Applicant Tracker' as the first non-featured project.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ae412d3-159b-498c-9033-7f2bfa675364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ae412d3-159b-498c-9033-7f2bfa675364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

